### PR TITLE
Change dependency URL for Snappy

### DIFF
--- a/snappy.go
+++ b/snappy.go
@@ -2,7 +2,7 @@ package sarama
 
 import (
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 	"encoding/binary"
 )
 


### PR DESCRIPTION
[Snappy has been migrated from Google Code to GitHub](https://github.com/golang/snappy/commit/eaa750b9bf4dcb7cb20454be850613b66cda3273). If you try to `go get` with the code.google.com URL in place, `go get` chokes because of the 302 redirect.

Upstream, Shopify did the same thing [here](https://github.com/Shopify/sarama/commit/6d47b6cfdee82ba22aee428ea46d9934c097f49b)
